### PR TITLE
Remove FEEDURL env var after migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,6 @@ When `unprocessed_entries > ENTRY_THRESHOLD_FOR_NEW_BOOK`:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `FEEDURL` | Remote URL | Primary feed list source |
 | `DOWNLOAD_PATH` | `/feeds` | Storage for HTML, cleaned, EPUB, db.json |
 | `DEBUG_MODE` | `false` | Limits to 2 feeds, sets dry_run |
 | `MAX_BATCH_SIZE` | `20` | Fails batch if exceeded |
@@ -135,10 +134,16 @@ make build          # Build Docker image
 docker-compose up   # Run with compose
 ```
 
+## GIT WORKFLOW
+
+- **PRs**: Always create a new branch from `main` for all changes, then open PR
+- **Branch naming**: Use descriptive names like `remove-feedurl`, `add-site-cleaner`
+- **Commits**: Keep atomic, use lowercase imperative style
+
 ## GOTCHAS
 
 1. **Two DB systems**: `feeder.py` uses TinyDB (`db.json`), legacy `webtoepub.py` uses pickle (`completedObjects.db`)
 2. **Title sanitization**: `sanitize_filename()` exists in both `feeder.py` and `utils.py` - use utils version
-3. **Feed fallback**: Remote `FEEDURL` fails → falls back to `feed.input.json`
+3. **Feed fallback**: If DB empty after migration, falls back to `feed.input.json`
 4. **Compiled books**: All entries marked processed even if email fails
 5. **Royal Road TOC scrape**: Requires `<table id="chapters">` - breaks if RR changes layout

--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ This project automates the workflow of reading web fiction on your e-reader:
 | `DEBUG_MODE` | `false` | Enable debug mode (dry run, limited feeds) |
 | `MAX_BATCH_SIZE` | `20` | Maximum emails to send in one batch |
 | `ENTRY_THRESHOLD_FOR_NEW_BOOK` | `5` | Number of unprocessed entries to trigger compiled ebook creation |
-| `FEEDURL` | - | URL to fetch remote feed list (optional) |
 | `WANDERING_INN_URL_FRAGMENT` | `wanderinginn` | URL fragment to detect Wandering Inn entries |
 | `TEST_FILE` | - | Path to test file for volume mount verification |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,6 @@ services:
       - MAX_BATCH_SIZE=20
       - ENTRY_THRESHOLD_FOR_NEW_BOOK=5
       
-      # Optional: Remote feed URL
-      # - FEEDURL=https://your-feed-server.com/api/feeds
-      
       # Optional: Test file for volume verification
       # - TEST_FILE=/feeds/.mounted
     restart: unless-stopped

--- a/feeder.py
+++ b/feeder.py
@@ -13,7 +13,6 @@ from mail import send_gmail
 import pypandoc
 import re
 
-FEEDURL = os.getenv("FEEDURL", "https://browse.sirius.moonblade.work/api/public/dl/hf_Ov0yq")
 WANDERING_INN_URL_FRAGMENT = os.getenv("WANDERING_INN_URL_FRAGMENT", "wanderinginn")
 DOWNLOAD_PATH = os.getenv("DOWNLOAD_PATH", "/feeds")
 DEBUG_MODE = os.getenv("DEBUG_MODE", "false") == "true"
@@ -35,19 +34,12 @@ def get_feed_list() -> Feed:
     if feeds:
         return Feed(feeds=feeds, dry_run=DEBUG_MODE)
     
-    # Fallback to remote/local JSON if DB is empty and migration failed
-    try:
-        response = requests.get(FEEDURL)
-        response.raise_for_status()
-        data = response.json()
+    # Fallback to local JSON if DB is empty and migration failed
+    logger.warn("No feeds in database, falling back to feed.input.json")
+    with open("./feed.input.json", 'r') as file:
+        data = json.load(file)
         feed = Feed(**data)
         return feed
-    except requests.RequestException as e:
-        logger.warn("Returning local feed due to error fetching remote feed.")
-        with open("./feed.input.json", 'r') as file:
-            data = json.load(file)
-            feed = Feed(**data)
-            return feed
 
 def sanitize_filename(filename: str) -> str:
     """


### PR DESCRIPTION
## Summary
- Remove deprecated `FEEDURL` environment variable and remote feed fetching logic
- Feeds now come exclusively from the database (migrated from `feed.input.json`)
- Fallback only to local `feed.input.json` if DB is empty
- Add git workflow guidelines to AGENTS.md

## Changes
- `feeder.py`: Remove `FEEDURL` env var and simplify `get_feed_list()` fallback
- `docker-compose.yml`: Remove commented `FEEDURL` config
- `README.md`: Remove `FEEDURL` from env vars table
- `AGENTS.md`: Update docs and add git workflow section