### PR TITLE
Split /feeds into /data and /config paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,8 @@ When `unprocessed_entries > ENTRY_THRESHOLD_FOR_NEW_BOOK`:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `DOWNLOAD_PATH` | `/feeds` | Storage for HTML, cleaned, EPUB, db.json |
+| `DATA_PATH` | `/data` | Storage for HTML, cleaned, EPUB files |
+| `CONFIG_PATH` | `/config` | Storage for db.json |
 | `DEBUG_MODE` | `false` | Limits to 2 feeds, sets dry_run |
 | `MAX_BATCH_SIZE` | `20` | Fails batch if exceeded |
 | `ENTRY_THRESHOLD_FOR_NEW_BOOK` | `5` | Triggers compiled ebook creation |
@@ -99,7 +100,7 @@ When `unprocessed_entries > ENTRY_THRESHOLD_FOR_NEW_BOOK`:
 
 ## DATABASE
 
-TinyDB at `$DOWNLOAD_PATH/db.json`. Entry keyed by `link`.
+TinyDB at `$CONFIG_PATH/db.json`. Entry keyed by `link`.
 
 **Patreon lock logic**: Entry ignored if `patreon_lock > current_time`. Set via `set_patreon_lock()` to `now + PATREON_LOCK_HOURS`.
 
@@ -112,7 +113,7 @@ TinyDB at `$DOWNLOAD_PATH/db.json`. Entry keyed by `link`.
 
 ## FILE ORGANIZATION
 
-Per-feed structure under `$DOWNLOAD_PATH`:
+Per-feed structure under `$DATA_PATH`:
 ```
 {feed_title}/
 ├── html/          # Raw downloaded HTML

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy requirements first to leverage Docker cache
 COPY requirements.txt .
 
-RUN mkdir -p /feeds && chmod 744 /feeds
+RUN mkdir -p /data /config && chmod 744 /data /config
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 SENDER_EMAIL:=$(shell cat secrets/mailconfig.json | jq -r '.sender_email')
 APP_PASSWORD:=$(shell cat secrets/mailconfig.json | jq -r '.app_password')
 TO_EMAIL:=$(shell cat secrets/mailconfig.json | jq -r '.to_email')
-DOWNLOAD_PATH:=/tmp/feeds
+DATA_PATH:=/tmp/data
+CONFIG_PATH:=/tmp/config
 UPDATE_FREQUENCY_SECONDS:=600
 # DEBUG_MODE:=true
 .EXPORT_ALL_VARIABLES:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ This project automates the workflow of reading web fiction on your e-reader:
        ports:
          - "9000:9000"
        volumes:
-         - ./feeds:/feeds
+         - ./data:/data
+         - ./config:/config
          - ./secrets/mailconfig.json:/app/secrets/mailconfig.json:ro
          - ./feed.input.json:/app/feed.input.json:ro
          - ./keywords.txt:/app/keywords.txt:ro
@@ -115,7 +116,8 @@ This project automates the workflow of reading web fiction on your e-reader:
          - SENDER_EMAIL=${SENDER_EMAIL}
          - APP_PASSWORD=${APP_PASSWORD}
          - TO_EMAIL=${TO_EMAIL}
-         - DOWNLOAD_PATH=/feeds
+         - DATA_PATH=/data
+         - CONFIG_PATH=/config
          - UPDATE_FREQUENCY_SECONDS=900  # 15 minutes
          - DEBUG_MODE=false
          - MAX_BATCH_SIZE=20
@@ -160,7 +162,8 @@ This project automates the workflow of reading web fiction on your e-reader:
    export SENDER_EMAIL="your-email@gmail.com"
    export APP_PASSWORD="your-gmail-app-password"
    export TO_EMAIL="your-kindle-email@kindle.com"
-   export DOWNLOAD_PATH="/tmp/feeds"
+   export DATA_PATH="/tmp/data"
+   export CONFIG_PATH="/tmp/config"
    export UPDATE_FREQUENCY_SECONDS=900
    ```
 
@@ -202,7 +205,8 @@ This project automates the workflow of reading web fiction on your e-reader:
 | `SENDER_EMAIL` | - | Gmail address to send from |
 | `APP_PASSWORD` | - | Gmail app password |
 | `TO_EMAIL` | - | Kindle email address |
-| `DOWNLOAD_PATH` | `/feeds` | Directory to store downloads and database |
+| `DATA_PATH` | `/data` | Directory to store downloads and EPUBs |
+| `CONFIG_PATH` | `/config` | Directory to store database (db.json) |
 | `UPDATE_FREQUENCY_SECONDS` | `900` | How often to check for new chapters (seconds) |
 | `DEBUG_MODE` | `false` | Enable debug mode (dry run, limited feeds) |
 | `MAX_BATCH_SIZE` | `20` | Maximum emails to send in one batch |
@@ -345,13 +349,13 @@ When more than 5 unprocessed entries are detected for a feed:
 - Ensure your Gmail address is in Kindle's approved sender list
 
 **"EPUB file not found" errors:**
-- Check DOWNLOAD_PATH exists and is writable
+- Check DATA_PATH exists and is writable
 - Verify Pandoc is installed (included in pypandoc_binary)
 - Check logs for download or conversion errors
 
 **No new chapters detected:**
 - Verify RSS feed URL is correct and accessible
-- Check if entries are already in database (`/feeds/db.json`)
+- Check if entries are already in database (`$CONFIG_PATH/db.json`)
 - Use revert feature to re-process specific chapters
 
 **Docker container exits:**

--- a/db.py
+++ b/db.py
@@ -4,12 +4,12 @@ import json
 from models import Entry, FeedItem
 from tinydb import TinyDB, Query
 
-DOWNLOAD_PATH = os.getenv("DOWNLOAD_PATH", "/feeds")
+CONFIG_PATH = os.getenv("CONFIG_PATH", "/config")
 
-if not os.path.exists(DOWNLOAD_PATH):
-    os.makedirs(DOWNLOAD_PATH)
+if not os.path.exists(CONFIG_PATH):
+    os.makedirs(CONFIG_PATH)
 
-db = TinyDB(os.path.join(DOWNLOAD_PATH, 'db.json'))
+db = TinyDB(os.path.join(CONFIG_PATH, 'db.json'))
 feeds_table = db.table('feeds')
 
 def add_entry(entry: Entry, feed: FeedItem):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,10 @@ services:
     ports:
       - "9000:9000"
     volumes:
-      # Persistent storage for feeds, EPUBs, and database
-      - ./feeds:/feeds
+      # Persistent storage for downloads and EPUBs
+      - ./data:/data
+      # Database and config storage
+      - ./config:/config
       # Configuration files (read-only)
       - ./secrets/mailconfig.json:/app/secrets/mailconfig.json:ro
       - ./feed.input.json:/app/feed.input.json:ro
@@ -20,14 +22,15 @@ services:
       - TO_EMAIL=${TO_EMAIL}
       
       # Application settings
-      - DOWNLOAD_PATH=/feeds
+      - DATA_PATH=/data
+      - CONFIG_PATH=/config
       - UPDATE_FREQUENCY_SECONDS=900  # 15 minutes
       - DEBUG_MODE=false
       - MAX_BATCH_SIZE=20
       - ENTRY_THRESHOLD_FOR_NEW_BOOK=5
       
       # Optional: Test file for volume verification
-      # - TEST_FILE=/feeds/.mounted
+      # - TEST_FILE=/data/.mounted
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/status"]

--- a/feeder.py
+++ b/feeder.py
@@ -14,7 +14,7 @@ import pypandoc
 import re
 
 WANDERING_INN_URL_FRAGMENT = os.getenv("WANDERING_INN_URL_FRAGMENT", "wanderinginn")
-DOWNLOAD_PATH = os.getenv("DOWNLOAD_PATH", "/feeds")
+DATA_PATH = os.getenv("DATA_PATH", "/data")
 DEBUG_MODE = os.getenv("DEBUG_MODE", "false") == "true"
 MAX_BATCH_SIZE = int(os.getenv("MAX_BATCH_SIZE", "20"))
 ENTRY_THRESHOLD_FOR_NEW_BOOK = int(os.getenv("ENTRY_THRESHOLD_FOR_NEW_BOOK", "5"))
@@ -78,7 +78,7 @@ def download(entry: Entry, feed: FeedItem):
     """
     Downloads the content of an entry to disk.
     """
-    feed_path = os.path.join(DOWNLOAD_PATH, sanitize_filename(feed.title))
+    feed_path = os.path.join(DATA_PATH, sanitize_filename(feed.title))
     html_download_path = os.path.join(feed_path, "html")
     os.makedirs(feed_path, exist_ok=True)
     os.makedirs(html_download_path, exist_ok=True)
@@ -157,7 +157,7 @@ def clean(entry: Entry, feed: FeedItem):
     """
     Cleans the downloaded content of an entry.
     """
-    feed_path = os.path.join(DOWNLOAD_PATH, sanitize_filename(feed.title))
+    feed_path = os.path.join(DATA_PATH, sanitize_filename(feed.title))
     html_download_path = os.path.join(feed_path, "html")
     html_file_path = os.path.join(html_download_path, f"{sanitize_filename(entry.title)}.html")
     cleaned_download_path = os.path.join(feed_path, "cleaned")
@@ -182,7 +182,7 @@ def convert_to_epub(entry: Entry, feed: FeedItem):
     """
     Converts the cleaned content of an entry to an EPUB file.
     """
-    feed_path = os.path.join(DOWNLOAD_PATH, sanitize_filename(feed.title))
+    feed_path = os.path.join(DATA_PATH, sanitize_filename(feed.title))
     cleaned_html_path = os.path.join(feed_path, "cleaned", f"{sanitize_filename(entry.title)}.html")
     epub_file_path_no_space = os.path.join(feed_path, f"{sanitize_filename(entry.get_file_name())}.epub")
     epub_file_path = os.path.join(feed_path, f"{sanitize_filename(entry.title)}.epub")
@@ -210,7 +210,7 @@ def prepare_email(entry: Entry, feed: FeedItem):
     Prepares an email for sending by validating the EPUB file exists and entry hasn't been sent.
     Returns None if the email shouldn't be sent.
     """
-    feed_path = os.path.join(DOWNLOAD_PATH, sanitize_filename(feed.title))
+    feed_path = os.path.join(DATA_PATH, sanitize_filename(feed.title))
     epub_file_path = os.path.join(feed_path, f"{sanitize_filename(entry.title)}.epub")
     
     if not os.path.exists(epub_file_path):
@@ -257,7 +257,7 @@ def send_email(entry: Entry, feed: FeedItem):
     """
     Sends an email with the EPUB file attached.
     """
-    feed_path = os.path.join(DOWNLOAD_PATH, sanitize_filename(feed.title))
+    feed_path = os.path.join(DATA_PATH, sanitize_filename(feed.title))
     epub_file_path = os.path.join(feed_path, f"{sanitize_filename(entry.title)}.epub")
     if not os.path.exists(epub_file_path):
         logger.error(f"EPUB file not found: {epub_file_path}")
@@ -374,7 +374,7 @@ def create_compiled_ebook(entries: List[Entry], feed: FeedItem):
     """
     Creates a single compiled ebook from multiple entries.
     """
-    feed_path = os.path.join(DOWNLOAD_PATH, sanitize_filename(feed.title))
+    feed_path = os.path.join(DATA_PATH, sanitize_filename(feed.title))
     compiled_epub_filename = f"{sanitize_filename(feed.title)}_compiled.epub"
     compiled_epub_path = os.path.join(feed_path, compiled_epub_filename)
         

--- a/main.py
+++ b/main.py
@@ -89,13 +89,13 @@ async def revert_entry(link: str):
     
     if deleted:
         # Delete associated files
-        download_path = os.getenv("DOWNLOAD_PATH", "/feeds")
+        data_path = os.getenv("DATA_PATH", "/data")
         feed_title = entry_to_delete.dict().get("feed", {}).get("title", "")
         
         deleted_files = delete_entry_files(
             entry_to_delete.title,
             feed_title,
-            download_path
+            data_path
         )
         
         logger.info(f"Reverted entry: {entry_to_delete.title} (deleted {deleted_files} files)")


### PR DESCRIPTION
## Summary
- Split single `/feeds` directory into separate `/data` and `/config` paths
- `/data` (`DATA_PATH`): Downloads, cleaned HTML, EPUB files
- `/config` (`CONFIG_PATH`): Database (db.json)

## Changes
- `db.py`: Use `CONFIG_PATH` for db.json location
- `feeder.py`, `main.py`: Rename `DOWNLOAD_PATH` → `DATA_PATH`
- `Dockerfile`: Create both `/data` and `/config` directories
- `docker-compose.yml`: Split volume mounts, update env vars
- `Makefile`: Update path defaults
- `README.md`, `AGENTS.md`: Update documentation