### PR TITLE
fix watermark detection skipping sentences without periods

### DIFF
--- a/feeder.py
+++ b/feeder.py
@@ -139,7 +139,7 @@ def clean_royal_road(html_content: str, keywords_to_remove: List[str]) -> str:
     extracted = False
     for para in chapter_div.find_all(["p", "div", "span"]):
         text = para.get_text().strip()
-        if "." in text and text.count(".") <= 3 and " " in text and text.count(" ") <= 25: #Check for . and space before count
+        if " " in text and text.count(" ") <= 25: #Check for space before count
             keywordsFound = 0
             for keyword in keywords_to_remove:
                 if keyword.lower() in text.lower():


### PR DESCRIPTION
## Summary
- Royal Road watermark detection in `clean_royal_road()` required a period (`.`) in the paragraph before checking keywords
- Watermark sentences ending with `!` or `?` (e.g. "Love this story? Find the genuine version on the author's preferred platform and support their work!") bypassed keyword matching entirely
- Removed the period check; the space count threshold (`<= 25 spaces`) is sufficient to limit matching to short paragraphs, and the 2+ keyword requirement prevents false positives